### PR TITLE
[Fix] Skip navigation on prevent default

### DIFF
--- a/src/link.tsx
+++ b/src/link.tsx
@@ -73,14 +73,20 @@ const RouteLinkView = <Params extends RouteParams>(
       {...linkProps}
       className={clsx(className, isOpened ? activeClassName : inactiveClassName)}
       onClick={(evt) => {
+        if (onClick) {
+          onClick(evt);
+        }
+
+        // allow user to prevent navigation
+        if (evt.defaultPrevented) {
+          return
+        }
+
         evt.preventDefault();
         navigate({
           params: params || ({} as Params),
           query: query || {},
         });
-        if (onClick) {
-          onClick(evt);
-        }
       }}
     >
       {children}


### PR DESCRIPTION
Allow user to prevent navigation to Route by using `event.preventDefault` inside `onClick` callback of `Link` component

Closes #19 