### PR TITLE
[Fix] Skip navigation for modified keys events and some "target" values

### DIFF
--- a/src/link.tsx
+++ b/src/link.tsx
@@ -47,6 +47,7 @@ const RouteLinkView = <Params extends RouteParams>(
     inactiveClassName,
     onClick,
     children,
+    target,
     ...linkProps
   } = props;
 
@@ -72,6 +73,7 @@ const RouteLinkView = <Params extends RouteParams>(
       href={href}
       {...linkProps}
       className={clsx(className, isOpened ? activeClassName : inactiveClassName)}
+      target={target}
       onClick={(evt) => {
         if (onClick) {
           onClick(evt);
@@ -79,6 +81,11 @@ const RouteLinkView = <Params extends RouteParams>(
 
         // allow user to prevent navigation
         if (evt.defaultPrevented) {
+          return
+        }
+
+        // let browser handle "_blank" target and etc
+        if (target && target !== '_self') {
           return
         }
 

--- a/src/link.tsx
+++ b/src/link.tsx
@@ -82,6 +82,11 @@ const RouteLinkView = <Params extends RouteParams>(
           return
         }
 
+        // skip modified events (like cmd + click to open the link in new tab)
+        if (evt.metaKey || evt.altKey || evt.ctrlKey || evt.shiftKey) {
+          return
+        }
+
         evt.preventDefault();
         navigate({
           params: params || ({} as Params),


### PR DESCRIPTION
Currently, when using `Link` component, if you try to open a link in a new tab, the behavior will be unexpected and default navigation will occur in the current tab. The same applies to links with `target="_blank"` attribute.

This PR adds a new logical steps, checking for `target` attribute and the mod keys (cmd, ctrl, alt, shift). When the key is pressed - the default `a` behavior will be used (if not default prevented by used).