### PR TITLE
[Chore] Fix esm extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,25 +10,25 @@
     "url": "https://github.com/atomic-router/react"
   },
   "license": "MIT",
-  "main": "dist/atomic-router.cjs.js",
-  "module": "dist/atomic-router.esm.js",
+  "main": "dist/atomic-router.js",
+  "module": "dist/atomic-router.mjs",
   "unpkg": "dist/atomic-router.umd.js",
   "types": "dist/atomic-router.d.ts",
   "exports": {
     ".": {
       "types": "./dist/atomic-router.d.ts",
-      "import": "./dist/atomic-router.esm.js",
-      "require": "./dist/atomic-router.cjs.js",
-      "node": "./dist/atomic-router.cjs.js",
-      "default": "./dist/atomic-router.esm.js"
+      "import": "./dist/atomic-router.mjs",
+      "require": "./dist/atomic-router.js",
+      "node": "./dist/atomic-router.js",
+      "default": "./dist/atomic-router.mjs"
     },
     "./package.json": "./package.json",
     "./scope": {
       "types": "./scope.d.ts",
-      "import": "./dist/scope/atomic-router.esm.js",
-      "require": "./dist/scope/atomic-router.cjs.js",
-      "node": "./dist/scope/atomic-router.cjs.js",
-      "default": "./dist/scope/atomic-router.esm.js"
+      "import": "./dist/scope/atomic-router.mjs",
+      "require": "./dist/scope/atomic-router.js",
+      "node": "./dist/scope/atomic-router.js",
+      "default": "./dist/scope/atomic-router.mjs"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "types": "dist/atomic-router.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/atomic-router.d.ts",
       "import": "./dist/atomic-router.mjs",
       "require": "./dist/atomic-router.js",
       "node": "./dist/atomic-router.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -108,6 +108,10 @@ export default [
         file: pkg.types,
         format: "es",
       },
+      {
+        file: pkg.types.replace(".d.ts", ".d.mts"),
+        format: "es",
+      }
     ],
     plugins: [resolverPlugin, dts()],
   },


### PR DESCRIPTION
Recently I ran into a problem when using `atomic-router-react` in ESM project with Node environment:

```shell
<REDACTED>/node_modules/atomic-router-react/dist/atomic-router.esm.js:1
import { withFactory } from 'effector';
^^^^^^
SyntaxError: Cannot use import statement outside a module
```

As publint says, `atomic-router.esm.js` is interpreted as CJS since it has `.js` extension and the `package.json` doesn't have `"type": "module"` line: https://publint.dev/atomic-router-react@0.9.0

This PR replaces `.esm.js` extensions with `.mjs`, so files can be interpreted as ESM without any breaking changes like adding `"type": "module"` line
