### PR TITLE
Fixed types for createRouteView

### DIFF
--- a/src/create-route-view.tsx
+++ b/src/create-route-view.tsx
@@ -13,7 +13,7 @@ export function createRouteView<
   Props,
   Params extends RouteParams
 >(config: RouteViewConfig<Props, Params>) {
-  return (props: Props & Omit<RouteViewConfig<Props, Params>, keyof Config>) => {
+  return (props: Props & Omit<RouteViewConfig<Props, Params>, keyof typeof config>) => {
     const mergedConfig = { ...config, ...props } as RouteViewConfig<Props, Params>;
     const isOpened = useIsOpened(mergedConfig.route);
 


### PR DESCRIPTION
In last commit I found type error in createRouteView function, generic type Config was used after deletion, I replaced it to `keyof typeof config`